### PR TITLE
remove improper call to CAMLparam from custom_operations finalization…

### DIFF
--- a/src/secp256k1_wrap.c
+++ b/src/secp256k1_wrap.c
@@ -15,7 +15,6 @@
 CAMLprim void
 ml_secp256k1_context_destroy (value ml_ctx)
 {
-    CAMLparam1 (ml_ctx);
     secp256k1_context_destroy (Context_val (ml_ctx));
 }
 


### PR DESCRIPTION
… routine

According to the "Interfacing C with OCAML" documentation, the "finalize" routine
of a block allocated with alloc_custom must not trigger a garbage collection, and
therefore should not use the CAMLparam or CAMLreturn macros. The code was
incorrectly calling CAMLparam, which triggered a segfault when performing a major
collection of the garbage collector.