### PR TITLE
Check the return values of secp256k1_ec_{priv,pub}key_negate

### DIFF
--- a/src/secp256k1_wrap.c
+++ b/src/secp256k1_wrap.c
@@ -98,6 +98,8 @@ ml_secp256k1_ec_privkey_negate(value ml_context, value ml_sk) {
     CAMLparam2 (ml_context, ml_sk);
     int ret = secp256k1_ec_privkey_negate(Context_val (ml_context),
                                           Caml_ba_data_val(ml_sk));
+    if (ret != 1)
+        caml_failwith ("ml_secp256k1_ec_privkey_negate");
     CAMLreturn(Val_unit);
 }
 
@@ -161,6 +163,8 @@ ml_secp256k1_ec_pubkey_negate(value ml_context, value ml_pk) {
     CAMLparam2 (ml_context, ml_pk);
     int ret = secp256k1_ec_pubkey_negate(Context_val (ml_context),
                                          Caml_ba_data_val(ml_pk));
+    if (ret != 1)
+        caml_failwith ("ml_secp256k1_ec_pubkey_negate");
     CAMLreturn(Val_unit);
 }
 


### PR DESCRIPTION
This removes warnings about unused variables from some cpp compilers.