### PR TITLE
Rewrote with GADTs

### DIFF
--- a/src/secp256k1.ml
+++ b/src/secp256k1.ml
@@ -17,6 +17,8 @@ module BA = struct
   let compare a b =
     compare_rec a b 0 (length a) (length b)
 
+  let equal a b = compare a b = 0
+
   let create len =
     Bigarray.(create char c_layout len)
 end
@@ -63,7 +65,7 @@ module Secret = struct
 
   type t = buffer
 
-  let compare = BA.compare
+  let equal = BA.equal
 
   let read ctx ?(pos=0) buf =
     let buflen = BA.length buf in
@@ -127,7 +129,7 @@ module Public = struct
 
   let length = 64
 
-  let compare = BA.compare
+  let equal = BA.equal
 
   external parse : Context.t -> buffer -> buffer -> bool =
     "ec_pubkey_parse" [@@noalloc]
@@ -218,7 +220,7 @@ end
 module Sign = struct
   type t = buffer
 
-  let compare = BA.compare
+  let equal = BA.equal
 
   let length = 64
 
@@ -311,7 +313,7 @@ module RecoverableSign = struct
 
   let length = 65
 
-  let compare = BA.compare
+  let equal = BA.equal
 
   external parse : Context.t -> buffer -> buffer -> int -> bool =
     "ecdsa_recoverable_signature_parse_compact" [@@noalloc]

--- a/src/secp256k1.mli
+++ b/src/secp256k1.mli
@@ -2,8 +2,8 @@ type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Arr
 
 module Context : sig
   type flag =
-    | Sign
     | Verify
+    | Sign
     (** which parts of the context to initialize. *)
 
   type t

--- a/src/secp256k1.mli
+++ b/src/secp256k1.mli
@@ -49,147 +49,98 @@ module Context : sig
 
 end
 
-module Secret : sig
-  type t
-  (** Opaque type of a valid ECDSA secret key. *)
+module Key : sig
+  type secret
+  type public
+  type _ t = private
+    | Sk : buffer -> secret t
+    | Pk : buffer -> public t
 
-  val length : int
-  (** Size of a secp256k1 secret key in bytes (32). *)
+  val to_buffer : _ t -> buffer
+  val length : _ t -> int
+  val equal : 'a t -> 'a t -> bool
+  val copy : 'a t -> 'a t
 
-  val equal : t -> t -> bool
+  (** {2 Aritmetic operations } *)
 
-  val read : Context.t -> ?pos:int -> buffer -> t option
-  val read_exn : Context.t -> ?pos:int -> buffer -> t
-  (** Verify an ECDSA secret key. At least 32 bytes must be read. *)
+  val negate : Context.t -> 'a t -> 'a t
+  val add_tweak : Context.t -> 'a t -> ?pos:int -> buffer -> 'a t
+  val mul_tweak : Context.t -> 'a t -> ?pos:int -> buffer -> 'a t
+  val neuterize : Context.t -> _ t -> public t option
+  val neuterize_exn : Context.t -> _ t -> public t
+  val combine : Context.t -> _ t list -> public t option
+  val combine_exn : Context.t -> _ t list -> public t
 
-  val write : buffer -> ?pos:int -> t -> unit
-  (** [write buf ?pos key] writes [key] at [buf] starting at [pos]. *)
+  (** {2 Input/Output} *)
 
-  val copy : t -> t
-  val to_bytes : t -> buffer
-
-  val negate : Context.t -> t -> t
-  val add_tweak : Context.t -> t -> ?pos:int -> buffer -> t
-  val mul_tweak : Context.t -> t -> ?pos:int -> buffer -> t
-end
-
-module Public : sig
-  type t
-  (** Opaque data structure that holds a parsed and valid public
-      key. *)
-
-  val equal : t -> t -> bool
-
-  val read : Context.t -> ?pos:int -> buffer -> t option
-  val read_exn : Context.t -> ?pos:int -> buffer -> t
-  (** Parse a variable-length public key. This function supports
-      parsing compressed (33 bytes, header byte 0x02 or 0x03),
-      uncompressed (65 bytes, header byte 0x04), or hybrid (65 bytes,
-      header byte 0x06 or 0x07) format public keys. *)
-
-  val of_secret : Context.t -> Secret.t -> t
-  (** Compute the public key for a secret key. *)
-
-  val write : ?compress:bool -> Context.t -> buffer -> ?pos:int -> t -> int
-  (** [write ?compress ctx buf ?pos key] writes [key] at [buf]
-      starting at [pos], and returns the number of bytes written. *)
-
-  val copy : t -> t
-  val to_bytes : ?compress:bool -> Context.t -> t -> buffer
-  (** Serialize a pubkey object into a serialized byte sequence. *)
-
-  val negate : Context.t -> t -> t
-  val add_tweak : Context.t -> t -> ?pos:int -> buffer -> t
-  val mul_tweak : Context.t -> t -> ?pos:int -> buffer -> t
-  val combine : Context.t -> t list -> t
+  val read_sk : Context.t -> ?pos:int -> buffer -> (secret t, string) result
+  val read_sk_exn : Context.t -> ?pos:int -> buffer -> secret t
+  val read_pk : Context.t -> ?pos:int -> buffer -> (public t, string) result
+  val read_pk_exn : Context.t -> ?pos:int -> buffer -> public t
+  val write : ?compress:bool -> Context.t -> ?pos:int -> buffer -> _ t -> int
+  val to_bytes : ?compress:bool -> Context.t -> _ t -> buffer
 end
 
 module Sign : sig
-  type t
-  (** Opaque data structure that holds a parsed ECDSA signature. *)
 
-  val equal : t -> t -> bool
+  (** {2 Message} *)
 
-  val of_compact : Context.t -> ?pos:int -> buffer -> t option
-  val of_compact_exn : Context.t -> ?pos:int -> buffer -> t
-  (** Parse an ECDSA signature in compact (64 bytes) format. Buffer
-      must be 64 bytes long. *)
+  type msg
 
-  val of_der : Context.t -> ?pos:int -> buffer -> t option
-  val of_der_exn : Context.t -> ?pos:int -> buffer -> t
-  (** Parse a DER ECDSA signature. *)
+  val msg_of_bytes : ?pos:int -> buffer -> msg option
+  val msg_of_bytes_exn : ?pos:int -> buffer -> msg
+  val write_msg_exn : ?pos:int -> buffer -> msg -> int
+  val write_msg : ?pos:int -> buffer -> msg -> (int, string) result
+  val msg_to_bytes : msg -> buffer
 
-  val to_compact : Context.t -> t -> buffer
-  (** Serialize an ECDSA signature in compact (64 byte) format. *)
+  (** {2 Signature} *)
 
-  val to_der : Context.t -> t -> buffer
-  (** Serialize an ECDSA signature in DER format. *)
+  type plain
+  type recoverable
+  type _ t = private
+    | P : buffer -> plain t
+    | R : buffer -> recoverable t
 
-  val write_compact : Context.t -> buffer -> ?pos:int -> t -> int
-  (** [write_compact ctx buf ?pos signature] writes [signature] at [buf]
-     starting at [pos] in compact format. *)
+  val equal : 'a t -> 'a t -> bool
+  val to_plain : Context.t -> recoverable t -> plain t
 
-  val write_der : Context.t -> buffer -> ?pos:int -> t -> int
-  (** [write_der ctx buf ?pos signature] writes [signature] at [buf]
-     starting at [pos] in DER format. *)
+  (** {3 Input/Output} *)
 
-  val sign : Context.t -> seckey:Secret.t -> ?pos:int -> buffer -> t
-  (** Create an ECDSA signature. The created signature is always in
-      lower-S form. Buffer must contain a 32-byte message hash. *)
+  val read : Context.t -> ?pos:int -> buffer -> (plain t, string) result
+  val read_exn : Context.t -> ?pos:int -> buffer -> plain t
+  val read_der : Context.t -> ?pos:int -> buffer -> (plain t, string) result
+  val read_der_exn : Context.t -> ?pos:int -> buffer -> plain t
+  val read_recoverable : Context.t -> recid:int -> ?pos:int -> buffer -> (recoverable t, string) result
+  val read_recoverable_exn : Context.t -> recid:int -> ?pos:int -> buffer -> recoverable t
 
-  val write_sign : Context.t -> seckey:Secret.t ->
-    outbuf:buffer -> ?outpos:int ->
-    inbuf:buffer -> ?inpos:int -> unit -> int
-  (** [write_sign ctx ~seckey ~outbuf ~outpos ~inbuf ~inpos ()] signs
-     the message at [inbuf] starting at [inpos] and writes the
-     signature at [outbuf] starting at [outpos] using [seckey], and
-     returns the number of bytes written. *)
+  val write_exn : ?der:bool -> Context.t -> ?pos:int -> buffer -> _ t -> int
+  val write : ?der:bool -> Context.t -> ?pos:int -> buffer -> _ t -> (int, string) result
+  val to_bytes : ?der:bool -> Context.t -> _ t -> buffer
+  val to_bytes_recid : Context.t -> recoverable t -> buffer * int
 
-  val verify :
-    Context.t -> pubkey:Public.t -> signature:t -> ?pos:int -> buffer -> bool
-  (** Verify an ECDSA signature. To avoid accepting malleable
-      signatures, only ECDSA signatures in lower-S form are
-      accepted. *)
-end
+  (** {3 Sign} *)
 
-module RecoverableSign : sig
-  type t
-  (** Opaque data structure that holds a parsed ECDSA recoverable
-      signature. *)
+  (** {4 Creation} *)
 
-  val equal : t -> t -> bool
+  val sign : Context.t -> sk:Key.secret Key.t -> msg:msg -> (plain t, string) result
+  val sign_exn : Context.t -> sk:Key.secret Key.t -> msg:msg -> plain t
+  val sign_recoverable : Context.t -> sk:Key.secret Key.t -> msg -> (recoverable t, string) result
+  val sign_recoverable_exn : Context.t -> sk:Key.secret Key.t -> msg -> recoverable t
 
-  val of_compact : Context.t -> recid:int -> ?pos:int -> buffer -> t option
-  val of_compact_exn : Context.t -> recid:int -> ?pos:int -> buffer -> t
-  (** Parse an ECDSA recoverable signature in compact (64 bytes)
-      format. Buffer must be 64 bytes.  The third argument is the
-      recovery id. *)
+  (** {4 Direct write in buffers} *)
 
-  val to_compact : Context.t -> t -> buffer * int
-  (** Serialize an ECDSA recoverable signature in compact (64 bytes)
-      format. The returned int is the recovery id. *)
+  val write_sign : Context.t -> sk:Key.secret Key.t -> msg:msg -> ?pos:int -> buffer -> (int, string) result
+  val write_sign_exn : Context.t -> sk:Key.secret Key.t -> msg:msg -> ?pos:int -> buffer -> int
+  val write_sign_recoverable : Context.t -> sk:Key.secret Key.t -> msg:msg -> ?pos:int -> buffer -> (int, string) result
+  val write_sign_recoverable_exn : Context.t -> sk:Key.secret Key.t -> msg:msg -> ?pos:int -> buffer -> int
 
-  val write_compact : Context.t -> buffer -> ?pos:int -> t -> int
-  (** [write_compact ctx buf ?pos signature] writes [signature] at [buf]
-      starting at [pos] in compact format. *)
+  (** {4 Verification} *)
 
-  val convert : Context.t -> t -> Sign.t
-  (** Convert an ECDSA recoverable signature into an ECDSA signature *)
+  val verify_exn : Context.t -> pk:Key.public Key.t -> msg:msg -> signature:_ t -> bool
+  val verify : Context.t -> pk:Key.public Key.t -> msg:msg -> signature:_ t -> (bool, string) result
 
-  val sign : Context.t -> seckey:Secret.t -> ?pos:int -> buffer -> t
-  (** Create an ECDSA recoverable signature. Buffer must contain
-      a 32-byte message hash. *)
+  (** {4 Recovery} *)
 
-  val write_sign :
-    Context.t -> seckey:Secret.t ->
-    outbuf:buffer -> ?outpos:int ->
-    inbuf:buffer -> ?inpos:int -> unit -> int
-  (** [write_sign ctx ~seckey ~outbuf ~outpos ~inbuf ~inpos ()] signs
-     the message at [inbuf] starting at [inpos] and writes the
-     signature at [outbuf] starting at [outpos] using [seckey], and
-     returns the number of bytes written. *)
-
-  val recover : Context.t -> t -> ?pos:int -> buffer -> Public.t option
-  (** Recover an ECDSA public key from a signature. Buffer must contain
-      a 32-byte message hash. *)
+  val recover_exn : Context.t -> signature:recoverable t -> msg:msg -> Key.public Key.t
+  val recover : Context.t -> signature:recoverable t -> msg:msg -> (Key.public Key.t, string) result
 end

--- a/src/secp256k1.mli
+++ b/src/secp256k1.mli
@@ -56,7 +56,7 @@ module Secret : sig
   val length : int
   (** Size of a secp256k1 secret key in bytes (32). *)
 
-  val compare : t -> t -> int
+  val equal : t -> t -> bool
 
   val read : Context.t -> ?pos:int -> buffer -> t option
   val read_exn : Context.t -> ?pos:int -> buffer -> t
@@ -78,7 +78,7 @@ module Public : sig
   (** Opaque data structure that holds a parsed and valid public
       key. *)
 
-  val compare : t -> t -> int
+  val equal : t -> t -> bool
 
   val read : Context.t -> ?pos:int -> buffer -> t option
   val read_exn : Context.t -> ?pos:int -> buffer -> t
@@ -108,7 +108,7 @@ module Sign : sig
   type t
   (** Opaque data structure that holds a parsed ECDSA signature. *)
 
-  val compare : t -> t -> int
+  val equal : t -> t -> bool
 
   val of_compact : Context.t -> ?pos:int -> buffer -> t option
   val of_compact_exn : Context.t -> ?pos:int -> buffer -> t
@@ -157,7 +157,7 @@ module RecoverableSign : sig
   (** Opaque data structure that holds a parsed ECDSA recoverable
       signature. *)
 
-  val compare : t -> t -> int
+  val equal : t -> t -> bool
 
   val of_compact : Context.t -> recid:int -> ?pos:int -> buffer -> t option
   val of_compact_exn : Context.t -> recid:int -> ?pos:int -> buffer -> t

--- a/src/secp256k1_wrap.c
+++ b/src/secp256k1_wrap.c
@@ -1,26 +1,24 @@
-#include <caml/mlvalues.h>
-#include <caml/alloc.h>
-#include <caml/memory.h>
-#include <caml/fail.h>
-#include <caml/custom.h>
-#include <caml/bigarray.h>
-
 #include <string.h>
+
 #include <secp256k1.h>
 #include <secp256k1_recovery.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/bigarray.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
 
 /* Accessing the secp256k1_context * part of an OCaml custom block */
 #define Context_val(v) (*((secp256k1_context **) Data_custom_val(v)))
 
-CAMLprim void
-ml_secp256k1_context_destroy (value ml_ctx)
-{
-    secp256k1_context_destroy (Context_val (ml_ctx));
+void context_destroy(value ctx) {
+    secp256k1_context_destroy (Context_val(ctx));
 }
 
 static struct custom_operations secp256k1_context_ops = {
     .identifier = "secp256k1_context",
-    .finalize = ml_secp256k1_context_destroy,
+    .finalize = context_destroy,
     .compare = custom_compare_default,
     .compare_ext = custom_compare_ext_default,
     .hash = custom_hash_default,
@@ -29,293 +27,202 @@ static struct custom_operations secp256k1_context_ops = {
 };
 
 static value alloc_context (secp256k1_context *ctx) {
-    value ml_ctx = alloc_custom (&secp256k1_context_ops, sizeof(secp256k1_context *),0, 1);
+    value ml_ctx = alloc_custom(&secp256k1_context_ops, sizeof(secp256k1_context *), 0, 1);
     Context_val(ml_ctx) = ctx;
     return ml_ctx;
 }
 
-/* Create a new secp256k1 context */
-CAMLprim value
-ml_secp256k1_context_create (value ml_flags)
-{
-    CAMLparam1 (ml_flags);
-
-    /* Parse context flag */
-    int flags = SECP256K1_CONTEXT_NONE;
-    switch (Int_val (ml_flags)) {
-    case 1:
-        flags = SECP256K1_CONTEXT_VERIFY;
-        break;
-    case 2:
-        flags = SECP256K1_CONTEXT_SIGN;
-        break;
-    case 3:
-        flags = SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY;
-        break;
-    };
-
-    /* Create and return context */
-    secp256k1_context *ctx = secp256k1_context_create (flags);
-
-    if (!ctx)
-        caml_failwith ("ml_secp256k1_context_create");
-
-    CAMLreturn (alloc_context(ctx));
+CAMLprim value context_flags (value buf) {
+    uint16_t *a = Caml_ba_data_val(buf);
+    a[0] = SECP256K1_CONTEXT_NONE;
+    a[1] = SECP256K1_CONTEXT_VERIFY;
+    a[2] = SECP256K1_CONTEXT_SIGN;
+    return Val_int(3 * sizeof(uint16_t));
 }
 
-/* Randomize the context */
-CAMLprim value
-ml_secp256k1_context_randomize (value ml_context, value ml_seed)
-{
-    CAMLparam2 (ml_context, ml_seed);
-    CAMLreturn(Val_bool(secp256k1_context_randomize(Context_val (ml_context),
-                                                    (const unsigned char*) String_val(ml_seed))));
+CAMLprim value context_create (value flags) {
+    CAMLparam1(flags);
+    secp256k1_context *ctx = secp256k1_context_create (Int_val(flags));
+    if (!ctx) caml_failwith("context_create");
+    CAMLreturn(alloc_context(ctx));
 }
 
-
-/* Clone the context */
-CAMLprim value
-ml_secp256k1_context_clone (value ml_context)
-{
-    CAMLparam1 (ml_context);
-    secp256k1_context *ctx = secp256k1_context_clone (Context_val (ml_context));
-
-    if (!ctx)
-        caml_failwith ("ml_secp256k1_context_clone");
-
-    CAMLreturn (alloc_context(ctx));
+CAMLprim value context_randomize (value ctx, value seed) {
+    return Val_bool(secp256k1_context_randomize(Context_val(ctx),
+                                                String_val(seed)));
 }
 
-CAMLprim value
-ml_secp256k1_ec_seckey_verify (value ml_context, value ml_seckey) {
-    CAMLparam2(ml_context, ml_seckey);
-    CAMLreturn(Val_bool(secp256k1_ec_seckey_verify(Context_val (ml_context),
-                                                   Caml_ba_data_val(ml_seckey))));
+CAMLprim value context_clone (value ctx) {
+    CAMLparam1(ctx);
+    secp256k1_context *new = secp256k1_context_clone (Context_val(ctx));
+    if (!new) caml_failwith("context_clone");
+    CAMLreturn(alloc_context(new));
 }
 
-CAMLprim value
-ml_secp256k1_ec_privkey_negate(value ml_context, value ml_sk) {
-    CAMLparam2 (ml_context, ml_sk);
-    int ret = secp256k1_ec_privkey_negate(Context_val (ml_context),
-                                          Caml_ba_data_val(ml_sk));
-    if (ret != 1)
-        caml_failwith ("ml_secp256k1_ec_privkey_negate");
-    CAMLreturn(Val_unit);
+CAMLprim value ec_seckey_verify (value ctx, value sk) {
+    return Val_bool(secp256k1_ec_seckey_verify(Caml_ba_data_val(ctx),
+                                               Caml_ba_data_val(sk)));
 }
 
-CAMLprim value
-ml_secp256k1_ec_privkey_tweak_add(value ml_context, value ml_sk, value ml_tweak) {
-    CAMLparam3 (ml_context, ml_sk, ml_tweak);
-
-    CAMLreturn(Val_bool(secp256k1_ec_privkey_tweak_add(Context_val (ml_context),
-                                                       Caml_ba_data_val(ml_sk),
-                                                       Caml_ba_data_val(ml_tweak))));
+CAMLprim value ec_privkey_negate(value ctx, value sk) {
+    int ret = secp256k1_ec_privkey_negate(Context_val (ctx),
+                                          Caml_ba_data_val(sk));
+    return Val_unit;
 }
 
-CAMLprim value
-ml_secp256k1_ec_privkey_tweak_mul(value ml_context, value ml_sk, value ml_tweak) {
-    CAMLparam3 (ml_context, ml_sk, ml_tweak);
-
-    CAMLreturn(Val_bool(secp256k1_ec_privkey_tweak_mul(Context_val (ml_context),
-                                                       Caml_ba_data_val(ml_sk),
-                                                       Caml_ba_data_val(ml_tweak))));
+CAMLprim value ec_privkey_tweak_add(value ctx, value sk, value tweak) {
+    return Val_bool(secp256k1_ec_privkey_tweak_add(Caml_ba_data_val(ctx),
+                                                   Caml_ba_data_val(sk),
+                                                   Caml_ba_data_val(tweak)));
 }
 
-/* Create public key */
-CAMLprim value
-ml_secp256k1_ec_pubkey_create (value ml_context, value ml_buf, value ml_seckey) {
-    CAMLparam3 (ml_context, ml_buf, ml_seckey);
-
-    CAMLreturn(Val_bool(secp256k1_ec_pubkey_create (Context_val (ml_context),
-                                                   Caml_ba_data_val(ml_buf),
-                                                   Caml_ba_data_val(ml_seckey))));
+CAMLprim value ec_privkey_tweak_mul(value ctx, value sk, value tweak) {
+    return Val_bool(secp256k1_ec_privkey_tweak_mul(Caml_ba_data_val(ctx),
+                                                   Caml_ba_data_val(sk),
+                                                   Caml_ba_data_val(tweak)));
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_serialize (value ml_context, value ml_buf, value ml_pubkey) {
-    CAMLparam3 (ml_context, ml_buf, ml_pubkey);
+CAMLprim value ec_pubkey_create (value ctx, value buf, value sk) {
+    return Val_bool(secp256k1_ec_pubkey_create (Caml_ba_data_val(ctx),
+                                                Caml_ba_data_val(buf),
+                                                Caml_ba_data_val(sk)));
+}
 
-    size_t size = Caml_ba_array_val(ml_buf)->dim[0];
+CAMLprim value ec_pubkey_serialize (value ctx, value buf, value pk) {
+    size_t size = Caml_ba_array_val(buf)->dim[0];
     unsigned int flags =
         size == 33 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
 
-    secp256k1_ec_pubkey_serialize(Context_val (ml_context),
-                                  Caml_ba_data_val(ml_buf),
+    secp256k1_ec_pubkey_serialize(Caml_ba_data_val(ctx),
+                                  Caml_ba_data_val(buf),
                                   &size,
-                                  Caml_ba_data_val(ml_pubkey),
+                                  Caml_ba_data_val(pk),
                                   flags);
 
-    CAMLreturn(Val_int(size));
+    return Val_int(size);
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_parse(value ml_context, value ml_buf, value ml_pk) {
-    CAMLparam3 (ml_context, ml_buf, ml_pk);
-
-    CAMLreturn(Val_bool(secp256k1_ec_pubkey_parse(Context_val (ml_context),
-                                                 Caml_ba_data_val(ml_buf),
-                                                 Caml_ba_data_val(ml_pk),
-                                                 Caml_ba_array_val(ml_pk)->dim[0])));
+CAMLprim value ec_pubkey_parse(value ctx, value buf, value pk) {
+    return Val_bool(secp256k1_ec_pubkey_parse(Caml_ba_data_val(ctx),
+                                              Caml_ba_data_val(buf),
+                                              Caml_ba_data_val(pk),
+                                              Caml_ba_array_val(pk)->dim[0]));
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_negate(value ml_context, value ml_pk) {
-    CAMLparam2 (ml_context, ml_pk);
-    int ret = secp256k1_ec_pubkey_negate(Context_val (ml_context),
-                                         Caml_ba_data_val(ml_pk));
-    if (ret != 1)
-        caml_failwith ("ml_secp256k1_ec_pubkey_negate");
-    CAMLreturn(Val_unit);
+CAMLprim value ec_pubkey_negate(value ctx, value pk) {
+    int ret = secp256k1_ec_pubkey_negate(Caml_ba_data_val(ctx),
+                                         Caml_ba_data_val(pk));
+    return Val_unit;
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_tweak_add(value ml_context, value ml_pk, value ml_tweak) {
-    CAMLparam3 (ml_context, ml_pk, ml_tweak);
-
-    CAMLreturn(Val_bool(secp256k1_ec_pubkey_tweak_add(Context_val (ml_context),
-                                                      Caml_ba_data_val(ml_pk),
-                                                      Caml_ba_data_val(ml_tweak))));
+CAMLprim value ec_pubkey_tweak_add(value ctx, value pk, value tweak) {
+    return Val_bool(secp256k1_ec_pubkey_tweak_add(Caml_ba_data_val(ctx),
+                                                  Caml_ba_data_val(pk),
+                                                  Caml_ba_data_val(tweak)));
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_tweak_mul(value ml_context, value ml_pk, value ml_tweak) {
-    CAMLparam3 (ml_context, ml_pk, ml_tweak);
-
-    CAMLreturn(Val_bool(secp256k1_ec_pubkey_tweak_mul(Context_val (ml_context),
-                                                      Caml_ba_data_val(ml_pk),
-                                                      Caml_ba_data_val(ml_tweak))));
+CAMLprim value ec_pubkey_tweak_mul(value ctx, value pk, value tweak) {
+    return Val_bool(secp256k1_ec_pubkey_tweak_mul(Caml_ba_data_val(ctx),
+                                                  Caml_ba_data_val(pk),
+                                                  Caml_ba_data_val(tweak)));
 }
 
-CAMLprim value
-ml_secp256k1_ec_pubkey_combine(value ml_context, value ml_out, value ml_pks) {
-    CAMLparam3 (ml_context, ml_out, ml_pks);
-
+CAMLprim value ec_pubkey_combine(value ctx, value out, value pks) {
     int size = 0;
-    const secp256k1_pubkey* pks[1024] = {0};
+    const secp256k1_pubkey* cpks[1024] = {0};
 
-    while(Field(ml_pks, 1) != Val_unit) {
-        pks[size] = Caml_ba_data_val(Field(ml_pks, 0));
+    while(Field(pks, 1) != Val_unit) {
+        cpks[size] = Caml_ba_data_val(Field(pks, 0));
         size++;
-        ml_pks = Field(ml_pks, 1);
+        pks = Field(pks, 1);
     }
 
-    CAMLreturn(Val_int(secp256k1_ec_pubkey_combine(Context_val (ml_context),
-                                                   Caml_ba_data_val(ml_out),
-                                                   pks,
-                                                   size)));
+    return Val_int(secp256k1_ec_pubkey_combine(Caml_ba_data_val(ctx),
+                                               Caml_ba_data_val(out),
+                                               cpks,
+                                               size));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_signature_parse_compact (value ml_context, value ml_buf, value ml_sig) {
-    CAMLparam3 (ml_context, ml_buf, ml_sig);
-    CAMLreturn(Val_bool(secp256k1_ecdsa_signature_parse_compact (Context_val (ml_context),
-                                                                Caml_ba_data_val(ml_buf),
-                                                                Caml_ba_data_val(ml_sig))));
+CAMLprim value ecdsa_signature_parse_compact (value ctx, value buf, value sig) {
+    return Val_bool(secp256k1_ecdsa_signature_parse_compact (Caml_ba_data_val(ctx),
+                                                             Caml_ba_data_val(buf),
+                                                             Caml_ba_data_val(sig)));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_signature_parse_der (value ml_context, value ml_buf, value ml_sig) {
-    CAMLparam3 (ml_context, ml_buf, ml_sig);
-    CAMLreturn(Val_bool(secp256k1_ecdsa_signature_parse_der (Context_val (ml_context),
-                                                            Caml_ba_data_val(ml_buf),
-                                                            Caml_ba_data_val(ml_sig),
-                                                            Caml_ba_array_val(ml_sig)->dim[0])));
+CAMLprim value ecdsa_signature_parse_der (value ctx, value buf, value sig) {
+    return Val_bool(secp256k1_ecdsa_signature_parse_der (Caml_ba_data_val(ctx),
+                                                         Caml_ba_data_val(buf),
+                                                         Caml_ba_data_val(sig),
+                                                         Caml_ba_array_val(sig)->dim[0]));
 }
 
-/* Verify an ecdsa signature */
-CAMLprim value
-ml_secp256k1_ecdsa_verify (value ml_context, value ml_pubkey, value ml_msg, value ml_signature) {
-    CAMLparam4 (ml_context, ml_signature, ml_msg, ml_pubkey);
-
-    CAMLreturn(Val_bool(secp256k1_ecdsa_verify (Context_val (ml_context),
-                                                Caml_ba_data_val(ml_signature),
-                                                Caml_ba_data_val(ml_msg),
-                                                Caml_ba_data_val(ml_pubkey))));
+CAMLprim value ecdsa_verify (value ctx, value pubkey, value msg, value signature) {
+    return Val_bool(secp256k1_ecdsa_verify (Caml_ba_data_val(ctx),
+                                            Caml_ba_data_val(signature),
+                                            Caml_ba_data_val(msg),
+                                            Caml_ba_data_val(pubkey)));
 }
 
 
-/* Sign a message with ECDSA */
-CAMLprim value
-ml_secp256k1_ecdsa_sign (value ml_context, value ml_buf, value ml_seckey, value ml_msg) {
-    CAMLparam4(ml_context, ml_buf, ml_seckey, ml_msg);
-
-    CAMLreturn(Val_bool(secp256k1_ecdsa_sign (Context_val (ml_context),
-                                              Caml_ba_data_val(ml_buf),
-                                              Caml_ba_data_val(ml_msg),
-                                              Caml_ba_data_val(ml_seckey),
-                                              NULL, NULL)));
+CAMLprim value ecdsa_sign (value ctx, value buf, value seckey, value msg) {
+    return Val_bool(secp256k1_ecdsa_sign (Caml_ba_data_val(ctx),
+                                          Caml_ba_data_val(buf),
+                                          Caml_ba_data_val(msg),
+                                          Caml_ba_data_val(seckey),
+                                          NULL, NULL));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_signature_serialize_der(value ml_context, value ml_buf, value ml_signature) {
-    CAMLparam3 (ml_context, ml_buf, ml_signature);
-
-    size_t size = Caml_ba_array_val(ml_buf)->dim[0];
-    int ret = secp256k1_ecdsa_signature_serialize_der(Context_val (ml_context),
-                                                      Caml_ba_data_val(ml_buf),
+CAMLprim value ecdsa_signature_serialize_der(value ctx, value buf, value signature) {
+    size_t size = Caml_ba_array_val(buf)->dim[0];
+    int ret = secp256k1_ecdsa_signature_serialize_der(Caml_ba_data_val(ctx),
+                                                      Caml_ba_data_val(buf),
                                                       &size,
-                                                      Caml_ba_data_val(ml_signature));
+                                                      Caml_ba_data_val(signature));
 
-    CAMLreturn(ret == 0 ? Val_int(ret) : Val_int(size));
+    return (ret == 0 ? Val_int(ret) : Val_int(size));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_signature_serialize_compact(value ml_context, value ml_buf, value ml_signature) {
-    CAMLparam3 (ml_context, ml_buf, ml_signature);
-
-    secp256k1_ecdsa_signature_serialize_compact(Context_val (ml_context),
-                                                Caml_ba_data_val(ml_buf),
-                                                Caml_ba_data_val(ml_signature));
-    CAMLreturn (Val_unit);
+CAMLprim value ecdsa_signature_serialize_compact(value ctx, value buf, value signature) {
+    secp256k1_ecdsa_signature_serialize_compact(Caml_ba_data_val(ctx),
+                                                Caml_ba_data_val(buf),
+                                                Caml_ba_data_val(signature));
+    return Val_unit;
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_recoverable_signature_parse_compact (value ml_context, value ml_buf, value ml_signature, value ml_recid) {
-    CAMLparam4 (ml_context, ml_buf, ml_signature, ml_recid);
-
-    CAMLreturn(Val_bool(secp256k1_ecdsa_recoverable_signature_parse_compact (Context_val (ml_context),
-                                                                             Caml_ba_data_val(ml_buf),
-                                                                             Caml_ba_data_val(ml_signature),
-                                                                             Int_val(ml_recid))));
+CAMLprim value ecdsa_recoverable_signature_parse_compact (value ctx, value buf, value signature, value recid) {
+    return Val_bool(secp256k1_ecdsa_recoverable_signature_parse_compact (Caml_ba_data_val(ctx),
+                                                                         Caml_ba_data_val(buf),
+                                                                         Caml_ba_data_val(signature),
+                                                                         Int_val(recid)));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_sign_recoverable (value ml_context, value ml_buf, value ml_seckey, value ml_msg) {
-    CAMLparam4(ml_context, ml_buf, ml_seckey, ml_msg);
-
-    CAMLreturn(Val_bool(secp256k1_ecdsa_sign_recoverable (Context_val (ml_context),
-                                                          Caml_ba_data_val(ml_buf),
-                                                          Caml_ba_data_val(ml_msg),
-                                                          Caml_ba_data_val(ml_seckey),
-                                                          NULL, NULL)));
+CAMLprim value ecdsa_sign_recoverable (value ctx, value buf, value seckey, value msg) {
+    return Val_bool(secp256k1_ecdsa_sign_recoverable (Caml_ba_data_val(ctx),
+                                                      Caml_ba_data_val(buf),
+                                                      Caml_ba_data_val(msg),
+                                                      Caml_ba_data_val(seckey),
+                                                      NULL, NULL));
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_recoverable_signature_serialize_compact(value ml_context, value ml_buf, value ml_signature) {
-    CAMLparam3 (ml_context, ml_buf, ml_signature);
+CAMLprim value ecdsa_recoverable_signature_serialize_compact(value ctx, value buf, value signature) {
     int recid;
-
-    secp256k1_ecdsa_recoverable_signature_serialize_compact(Context_val (ml_context),
-                                                            Caml_ba_data_val(ml_buf),
+    secp256k1_ecdsa_recoverable_signature_serialize_compact(Caml_ba_data_val(ctx),
+                                                            Caml_ba_data_val(buf),
                                                             &recid,
-                                                            Caml_ba_data_val(ml_signature));
-    CAMLreturn(Val_int(recid));
+                                                            Caml_ba_data_val(signature));
+    return Val_int(recid);
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_recoverable_signature_convert(value ml_context, value ml_buf, value ml_signature) {
-    CAMLparam3 (ml_context, ml_buf, ml_signature);
-    secp256k1_ecdsa_recoverable_signature_convert (Context_val (ml_context),
-                                                   Caml_ba_data_val(ml_buf),
-                                                   Caml_ba_data_val(ml_signature));
-    CAMLreturn(Val_unit);
+CAMLprim value ecdsa_recoverable_signature_convert(value ctx, value buf, value signature) {
+    secp256k1_ecdsa_recoverable_signature_convert(Caml_ba_data_val(ctx),
+                                                   Caml_ba_data_val(buf),
+                                                   Caml_ba_data_val(signature));
+    return Val_unit;
 }
 
-CAMLprim value
-ml_secp256k1_ecdsa_recover(value ml_context, value ml_buf, value ml_signature, value ml_msg) {
-    CAMLparam4 (ml_context, ml_buf, ml_signature, ml_msg);
-    CAMLreturn(Val_bool(secp256k1_ecdsa_recover(Context_val (ml_context),
-                                                Caml_ba_data_val(ml_buf),
-                                                Caml_ba_data_val(ml_signature),
-                                                Caml_ba_data_val(ml_msg))));
+CAMLprim value ecdsa_recover(value ctx, value buf, value signature, value msg) {
+    return Val_bool(secp256k1_ecdsa_recover(Caml_ba_data_val(ctx),
+                                            Caml_ba_data_val(buf),
+                                            Caml_ba_data_val(signature),
+                                            Caml_ba_data_val(msg)));
 }

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,15 +3,15 @@ open OUnit2
 
 let signature_of_string ctx s =
   let { Cstruct.buffer } = Hex.to_cstruct s in
-  Sign.of_der_exn ctx buffer
+  Sign.read_der_exn ctx buffer
 
 let pk_of_string ctx s =
   let { Cstruct.buffer } = Hex.to_cstruct s in
-  Public.read_exn ctx buffer
+  Key.read_pk_exn ctx buffer
 
 let sk_of_string ctx s =
   let { Cstruct.buffer } = Hex.to_cstruct s in
-  Secret.read_exn ctx buffer
+  Key.read_sk_exn ctx buffer
 
 let buffer_of_string s =
   let { Cstruct.buffer } = Hex.to_cstruct s in
@@ -27,37 +27,37 @@ let test_signature_of_string octx =
   let sign_orig_hex = sanitize_hex
       "3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589" in
   let signature = signature_of_string ctx sign_orig_hex in
-  let sign = Sign.to_der ctx signature in
+  let sign = Sign.to_bytes ~der:true ctx signature in
   let sign_hex = Hex.of_cstruct (Cstruct.of_bigarray sign) in
   assert_equal ~printer:hex_printer sign_orig_hex sign_hex
 
 let test_valid_signature octx =
   let ctx = Context.create [Verify] in
-  let msg = buffer_of_string
+  let msg = Sign.msg_of_bytes_exn @@ buffer_of_string
       (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90") in
   let signature = signature_of_string ctx
       (`Hex "3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589") in
-  let pubkey = pk_of_string ctx
+  let pk = pk_of_string ctx
       (`Hex "040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40") in
-  assert_equal true (Sign.verify ctx ~signature ~pubkey msg)
+  assert_equal true (Sign.verify_exn ctx ~signature ~pk ~msg)
 
 let test_invalid_signature octx =
   let ctx = Context.create [Verify] in
-  let msg = buffer_of_string
+  let msg = Sign.msg_of_bytes_exn @@ buffer_of_string
       (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91") in
   let signature = signature_of_string ctx
       (`Hex "3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589") in
-  let pubkey = pk_of_string ctx
+  let pk = pk_of_string ctx
       (`Hex "040a629506e1b65cd9d2e0ba9c75df9c4fed0db16dc9625ed14397f0afc836fae595dc53f8b0efe61e703075bd9b143bac75ec0e19f82a2208caeb32be53414c40") in
-  assert_equal false (Sign.verify ctx ~signature ~pubkey msg)
+  assert_equal false (Sign.verify_exn ctx ~signature ~pk ~msg)
 
 let test_public_module octx =
   let pubtrue_hex =
     `Hex "04c591a8ff19ac9c4e4e5793673b83123437e975285e7b442f4ee2654dffca5e2d2103ed494718c697ac9aebcfd19612e224db46661011863ed2fc54e71861e2a6" in
   let pubtrue = buffer_of_string pubtrue_hex in
-  let pub = Public.read_exn ctx pubtrue in
+  let pub = Key.read_pk_exn ctx pubtrue in
   let pub_serialized =
-    Public.to_bytes ~compress:false ctx pub |>
+    Key.to_bytes ~compress:false ctx pub |>
     Cstruct.of_bigarray |>
     Hex.of_cstruct in
   assert_equal ~printer:hex_printer pubtrue_hex pub_serialized
@@ -65,45 +65,46 @@ let test_public_module octx =
 let test_pubkey_creation octx =
   let seckey = buffer_of_string (`Hex "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530") in
   let pubtrue = `Hex "04c591a8ff19ac9c4e4e5793673b83123437e975285e7b442f4ee2654dffca5e2d2103ed494718c697ac9aebcfd19612e224db46661011863ed2fc54e71861e2a6" in
-  let seckey = Secret.read_exn ctx seckey in
-  let pubkey = Public.of_secret ctx seckey in
+  let seckey = Key.read_sk_exn ctx seckey in
+  let pubkey = Key.neuterize_exn ctx seckey in
   let buf_pk_comp = Cstruct.create 33 in
   let buf_pk_uncomp = Cstruct.create 65 in
-  let nb_written = Public.write ~compress:true ctx buf_pk_comp.buffer pubkey in
+  let nb_written = Key.write ~compress:true ctx buf_pk_comp.buffer pubkey in
   assert_equal 33 nb_written ;
-  let nb_written = Public.write ~compress:false ctx buf_pk_uncomp.buffer pubkey in
+  let nb_written = Key.write ~compress:false ctx buf_pk_uncomp.buffer pubkey in
   assert_equal 65 nb_written ;
-  let nb_written = Public.write ~compress:true ctx buf_pk_uncomp.buffer ~pos:32 pubkey in
+  let nb_written = Key.write ~compress:true ctx buf_pk_uncomp.buffer ~pos:32 pubkey in
   assert_equal 33 nb_written ;
   let pubkey_serialized =
-    Public.to_bytes ~compress:false ctx pubkey |>
+    Key.to_bytes ~compress:false ctx pubkey |>
     Cstruct.of_bigarray |>
     Hex.of_cstruct in
   assert_equal ~printer:hex_printer pubtrue pubkey_serialized
 
 let test_sign octx =
   let ctx = Context.create [Sign] in
-  let msg = buffer_of_string (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90") in
-  let seckey = sk_of_string ctx (`Hex "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530") in
+  let msg = Sign.msg_of_bytes_exn @@ buffer_of_string (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90") in
+  let sk = sk_of_string ctx (`Hex "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530") in
   let validsign = signature_of_string ctx (`Hex "30440220182a108e1448dc8f1fb467d06a0f3bb8ea0533584cb954ef8da112f1d60e39a202201c66f36da211c087f3af88b50edf4f9bdaa6cf5fd6817e74dca34db12390c6e9") in
-  let sign = Sign.sign ctx ~seckey msg in
+  let sign = Sign.sign_exn ctx ~sk ~msg in
   assert_equal true (Sign.equal sign validsign)
 
 let test_recover octx =
-  let ctx = Context.create [Sign] in
-  let msg = buffer_of_string (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90") in
+  let ctx = Context.create [Sign; Verify] in
+  let msg = Sign.msg_of_bytes_exn @@ buffer_of_string (`Hex "CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90") in
   let seckey = sk_of_string ctx (`Hex "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530") in
-  let pubkey = Public.of_secret ctx seckey in
-  let recoverable_sign = RecoverableSign.sign ctx seckey msg in
-  let usual_sign = RecoverableSign.convert ctx recoverable_sign in
-  let verify_ctx = Context.create [Verify] in
-  assert (Sign.verify verify_ctx pubkey usual_sign msg);
-  let (compact, recid) = RecoverableSign.to_compact verify_ctx recoverable_sign in
-  let parsed = RecoverableSign.of_compact_exn verify_ctx compact ~recid in
-  assert_equal true (RecoverableSign.equal parsed recoverable_sign);
-  match RecoverableSign.recover verify_ctx recoverable_sign msg with
-  | None -> assert false
-  | Some recovered -> assert_equal true (Public.equal recovered pubkey)
+  let pubkey = Key.neuterize_exn ctx seckey in
+  let recoverable_sign = Sign.sign_recoverable_exn ctx seckey msg in
+  let usual_sign = Sign.to_plain ctx recoverable_sign in
+  assert (Sign.verify_exn ctx ~pk:pubkey ~signature:usual_sign ~msg);
+  let compact, recid = Sign.to_bytes_recid ctx recoverable_sign in
+  let usual_sign' = Sign.read_exn ctx compact in
+  assert (Sign.equal usual_sign' usual_sign) ;
+  let parsed = Sign.read_recoverable_exn ctx compact ~recid in
+  assert (Sign.equal parsed recoverable_sign);
+  match Sign.recover ctx recoverable_sign msg with
+  | Error _ -> assert false
+  | Ok recovered -> assert_equal true (Key.equal recovered pubkey)
 
 let suite =
   "secp256k1" >::: [

--- a/test/test.ml
+++ b/test/test.ml
@@ -87,7 +87,7 @@ let test_sign octx =
   let seckey = sk_of_string ctx (`Hex "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530") in
   let validsign = signature_of_string ctx (`Hex "30440220182a108e1448dc8f1fb467d06a0f3bb8ea0533584cb954ef8da112f1d60e39a202201c66f36da211c087f3af88b50edf4f9bdaa6cf5fd6817e74dca34db12390c6e9") in
   let sign = Sign.sign ctx ~seckey msg in
-  assert_equal 0 (Sign.compare sign validsign)
+  assert_equal true (Sign.equal sign validsign)
 
 let test_recover octx =
   let ctx = Context.create [Sign] in
@@ -100,10 +100,10 @@ let test_recover octx =
   assert (Sign.verify verify_ctx pubkey usual_sign msg);
   let (compact, recid) = RecoverableSign.to_compact verify_ctx recoverable_sign in
   let parsed = RecoverableSign.of_compact_exn verify_ctx compact ~recid in
-  assert_equal 0 (RecoverableSign.compare parsed recoverable_sign);
+  assert_equal true (RecoverableSign.equal parsed recoverable_sign);
   match RecoverableSign.recover verify_ctx recoverable_sign msg with
   | None -> assert false
-  | Some recovered -> assert_equal 0 (Public.compare recovered pubkey)
+  | Some recovered -> assert_equal true (Public.equal recovered pubkey)
 
 let suite =
   "secp256k1" >::: [


### PR DESCRIPTION
I made a big refactoring where I use GADTs to improve the interface.
The advantage of using GADTs is that some functions can be compacted, i.e. one can a unique `write` function to write either a secret or public key.

I personally prefer interfaces like this that GADTs makes possible nowadays.