### PR TITLE
Add support for OCaml 5.x

### DIFF
--- a/src/secp256k1_wrap.c
+++ b/src/secp256k1_wrap.c
@@ -27,7 +27,7 @@ static struct custom_operations secp256k1_context_ops = {
 };
 
 static value alloc_context (secp256k1_context *ctx) {
-    value ml_ctx = alloc_custom(&secp256k1_context_ops, sizeof(secp256k1_context *), 0, 1);
+    value ml_ctx = caml_alloc_custom(&secp256k1_context_ops, sizeof(secp256k1_context *), 0, 1);
     Context_val(ml_ctx) = ctx;
     return ml_ctx;
 }


### PR DESCRIPTION
The compatibility macro was removed in OCaml 5.0 #10863

Fixes:

```
dune utop
Fatal error: cannot load shared library dllsecp256k1_stubs
Reason: /home/juergen/ghq/github.com/dakk/secp256k1-ml/_build/default/src/dllsecp256k1_stubs.so: undefined symbol: alloc_custom
Aborted (core dumped)
```